### PR TITLE
feat:add support for harmony#1

### DIFF
--- a/src/predefinedComponents/common/components/HeaderWrapper.tsx
+++ b/src/predefinedComponents/common/components/HeaderWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { ImageSourcePropType } from 'react-native';
-import { StyleSheet, View, useWindowDimensions } from 'react-native';
-import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+import { StyleSheet, View, useWindowDimensions,Text} from 'react-native';
+import Animated, { useAnimatedStyle,interpolate,Extrapolate} from 'react-native-reanimated';
 
 import { colors } from '../../../constants';
 import type { AnimatedColorProp } from '../SharedProps';
@@ -34,70 +34,64 @@ export const HeaderWrapper: React.FC<React.PropsWithChildren<HeaderWrapperProps>
 }) => {
   const { width } = useWindowDimensions();
   const hasBackgroundImage = !!backgroundImage;
-  const contentAnimatedStyle = useAnimatedStyle(() => {
-    // TypeScript complains about AnimatedNode<StyleProp<ViewStyle>> from reanimated v1
-    return { backgroundColor: parseAnimatedColorProp(contentBackgroundColor) as string };
-  }, [contentBackgroundColor]);
   const foregroundAnimatedStyle = useAnimatedStyle(() => {
-    if (hasBackgroundImage) {
-      return { backgroundColor: colors.transparent };
+    if (!hasBorderRadius) {
+      return { borderBottomEndRadius: 0,backgroundColor};
     }
-
     return {
-      backgroundColor: parseAnimatedColorProp(tabsContainerBackgroundColor),
+      backgroundColor: hasBackgroundImage?colors.transparent:backgroundColor,
+      transform:[
+        {
+          translateY:-scrollValue.value
+        }
+      ],
+      borderBottomEndRadius: interpolate(
+        scrollValue.value,
+        [0, scrollHeight],
+        [80, 0],
+        Extrapolate.EXTEND
+      ),
     };
-  }, [hasBackgroundImage, tabsContainerBackgroundColor]);
+  }, [hasBackgroundImage,backgroundColor, hasBorderRadius,tabsContainerBackgroundColor,scrollValue,scrollHeight]);
 
   return (
-    <Animated.View pointerEvents="box-none" style={contentAnimatedStyle}>
-      {backgroundImage ? (
-        <View pointerEvents="none">
-          <HeaderBackgroundImage
-            background={
-              <HeaderBackground
-                backgroundColor={backgroundColor}
-                hasBorderRadius={hasBorderRadius}
-                height={parallaxHeight}
-                scrollValue={scrollValue}
-              />
-            }
-            backgroundHeight={scrollHeight}
-            backgroundImage={backgroundImage}
-          />
-        </View>
-      ) : (
-        <View
-          pointerEvents="none"
-          style={[styles.headerStyle, { height: scrollHeight }, { width }]}>
-          <HeaderBackground
-            backgroundColor={backgroundColor}
-            hasBorderRadius={hasBorderRadius}
-            height={parallaxHeight}
-            scrollValue={scrollValue}
-          />
-        </View>
-      )}
-      <Animated.View
-        pointerEvents="box-none"
-        style={[
-          {
-            height: scrollHeight,
-          },
-          foregroundAnimatedStyle,
-        ]}
-        testID="HeaderForeground">
-        {children}
-      </Animated.View>
-    </Animated.View>
+      <View style={[styles.handler,{ height: scrollHeight,width}]}>
+          <View style={[styles.headerStyle,{ height: scrollHeight,width,backgroundImage:backgroundImage}]}>
+            <Animated.View
+            pointerEvents="box-none"
+            style={[
+              {
+                width:'100%',
+                height: scrollHeight,
+                borderBottomEndRadius:200
+              },
+              foregroundAnimatedStyle,
+            ]}
+            testID="HeaderForeground">
+            {children}
+          </Animated.View>
+          </View>
+      </View>
   );
 };
 
 const styles = StyleSheet.create({
   headerStyle: {
-    position: 'absolute',
+    position: 'relative',
     left: 0,
     top: 0,
     alignItems: 'flex-start',
     justifyContent: 'flex-end',
+    backgroundColor:'transparent'
+  },
+  handler: {
+    position:'relative'
+  },
+  bacPanel:{
+    height:2000
+  },
+  handlerText: {
+    fontSize: 24,
+    color: 'red',
   },
 });


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
#1
react-native-sticky-parallax-header是一个简单的React Native库，提供一系列用于创建自定义header布局的组件。目前只有android和iOS上面实现,harmony侧的能力需要自研进行实现。本库基于原库的基础上，对标iOS实现harmony侧的适配。
本次修改要点：
+ 适配harmony,add support for harmony
+ 修改部分HeaderWrapper.tsx公共组件样式布局相关的代码保证harmony与iOS侧效果一致

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
