### PR TITLE
pre-release:@react-native-ohos/react-native-sticky-parallax-header@1.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.2.0-rc.3
+
+## Updated content
+* fix:Fix the issue where the initialPage attribute in TabbedHeader is overwritten
+
 # v1.2.0-rc.2
 
 ## Updated content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-ohos/react-native-sticky-parallax-header",
-  "version": "1.2.0-rc.2",
+  "version": "1.2.0-rc.3",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",


### PR DESCRIPTION
fix:Fix the issue where the initialPage attribute in TabbedHeader is overwritten