### PR TITLE
fix: pagerwithAvatarHeaderFlashList子项点击默认组件不显示，onHeaderLayout回调已调用

### DIFF
--- a/src/primitiveComponents/withStickyHeaderFlashList.tsx
+++ b/src/primitiveComponents/withStickyHeaderFlashList.tsx
@@ -30,6 +30,7 @@ export function withStickyHeaderFlashList<T extends React.ComponentClass<FlashLi
       onTabsLayout,
       renderHeader,
       renderTabs,
+      onHeaderLayout,
       scrollEventThrottle = 16,
       ...rest
     } = props;
@@ -51,6 +52,7 @@ export function withStickyHeaderFlashList<T extends React.ComponentClass<FlashLi
 	  onScrollBeginDrag,
       onScrollEndDrag,
       onTabsLayout,
+      onHeaderLayout,
     });
     const flattenContentContainerStyle = React.useMemo(() => {
       return StyleSheet.flatten([


### PR DESCRIPTION
Pager with Avatar Header FlashList子项 点击蓝色字体AvatarHeaderFlashList默认组件 onHeaderLayout不显示"onHeaderLayout回调已调用"
