### PR TITLE
pre-release:@react-native-ohos/react-native-sticky-parallax-header@1.2.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.2.0-rc.4
+
+## Updated content
+* fix:Fix the issue where the onHeadLayout isn't invoke
+  
 # v1.2.0-rc.3
 
 ## Updated content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-ohos/react-native-sticky-parallax-header",
-  "version": "1.2.0-rc.3",
+  "version": "1.2.0-rc.4",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",

--- a/src/primitiveComponents/withStickyHeaderFlashList.tsx
+++ b/src/primitiveComponents/withStickyHeaderFlashList.tsx
@@ -30,6 +30,7 @@ export function withStickyHeaderFlashList<T extends React.ComponentClass<FlashLi
       onTabsLayout,
       renderHeader,
       renderTabs,
+      onHeaderLayout,
       scrollEventThrottle = 16,
       ...rest
     } = props;
@@ -51,6 +52,7 @@ export function withStickyHeaderFlashList<T extends React.ComponentClass<FlashLi
 	  onScrollBeginDrag,
       onScrollEndDrag,
       onTabsLayout,
+      onHeaderLayout,
     });
     const flattenContentContainerStyle = React.useMemo(() => {
       return StyleSheet.flatten([


### PR DESCRIPTION
Fix the issue where the onHeadLayout isn't invoke